### PR TITLE
Revert "Fixing API Spam due to recursion"

### DIFF
--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
@@ -60,20 +60,17 @@ public class RipSrcAudioManager implements HttpConfigurable, AudioSourceManager,
 	}
 
 	@Override
-	    public @Nullable AudioSearchResult loadSearch(@NotNull String query, @NotNull Set<AudioSearchResult.Type> types) {
-	        if (!types.isEmpty() && !types.stream().allMatch(t -> t.equals(AudioSearchResult.Type.TRACK))) {
-	            throw new RuntimeException(getSourceName() + " can only search tracks");
-	        }
-	        try {
-	            AudioSearchResult result = getSearchResults(query);
-	            if (result.getTracks().isEmpty()) {
-	                return null;
-	            }
-	            return result;
-	        } catch (IOException e) {
-	            throw new RuntimeException(e);
-	        }
-	    }
+	public @Nullable AudioSearchResult loadSearch(@NotNull String s, @NotNull Set<AudioSearchResult.Type> set) {
+		if (!set.isEmpty() && !set.stream().allMatch(it -> it.equals(AudioSearchResult.Type.TRACK))) {
+			throw new RuntimeException(getSourceName() + " can only search tracks");
+		}
+		try {
+			return getSearchResults(s);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
 
 	private AudioSearchResult getSearchResults(String s) throws IOException {
 		var json = getJson(getSearchUrl(s));


### PR DESCRIPTION
Reverts kikkia/ripsrc#1

It looks like the way we had it was the correct pattern for not returning null. Going to keep digging a little into this issue that was reported though