### PR TITLE
Correctly pass content length to stream

### DIFF
--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
@@ -8,6 +8,7 @@ import com.kikkia.ripsrc.utils.HttpClientUtils;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
+import com.sedmelluq.discord.lavaplayer.tools.Units;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpConfigurable;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
@@ -147,7 +148,11 @@ public class RipSrcAudioManager implements HttpConfigurable, AudioSourceManager,
 
 	private AudioTrack parseTrack(JsonBrowser json) {
 		var id = json.get("id").text();
-		var url = json.get("versions").index(0).get("url").text() + "&codec=" + json.get("versions").index(0).get("codec").text();
+		var version = json.get("versions").index(0);
+		var codec = version.get("codec").text();
+		var contentLength = version.get("size").asLong(Units.CONTENT_LENGTH_UNKNOWN);
+		var url = version.get("url").text() + "&codec=" + codec + "&clen=" + contentLength;
+
 		var track = new AudioTrackInfo(
 			json.get("title").text(),
 			json.get("artist").text(),
@@ -158,6 +163,7 @@ public class RipSrcAudioManager implements HttpConfigurable, AudioSourceManager,
 			json.get("picture").text(),
 			json.get("isrc").index(0).text()
 		);
+
 		return new RipSrcAudioTrack(track, this);
 	}
 

--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
@@ -3,13 +3,17 @@ package com.kikkia.ripsrc;
 import com.sedmelluq.discord.lavaplayer.container.matroska.MatroskaAudioTrack;
 import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
+import com.sedmelluq.discord.lavaplayer.tools.Units;
 import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import com.sedmelluq.discord.lavaplayer.track.DelegatedAudioTrack;
-import com.sedmelluq.discord.lavaplayer.track.InternalAudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RipSrcAudioTrack extends DelegatedAudioTrack {
 	private final RipSrcAudioManager audioManager;
@@ -22,15 +26,21 @@ public class RipSrcAudioTrack extends DelegatedAudioTrack {
 	@Override
 	public void process(LocalAudioTrackExecutor localAudioTrackExecutor) throws Exception {
 		var downloadLink = this.trackInfo.uri;
+		var queryParams = parseQueryParams(downloadLink);
+
+		var codec = queryParams.get("codec");
+		var contentLength = queryParams.get("clen");
 
 		try (var httpInterface = this.audioManager.getHttpInterface();
-			 var stream = new PersistentHttpStream(httpInterface, new URI(downloadLink), this.trackInfo.length)) {
+			 var stream = new PersistentHttpStream(httpInterface, new URI(downloadLink), contentLength != null ? Long.parseLong(contentLength) : Units.CONTENT_LENGTH_UNKNOWN)) {
 
 			// Atm only see mpeg or webm
-			if (downloadLink.contains("&codec=mp4a")) {
+			if (codec.equals("opus")) {
 				processDelegate(new MpegAudioTrack(this.trackInfo, stream), localAudioTrackExecutor);
-			} else {
+			} else if (codec.equals("mp4a")) {
 				processDelegate(new MatroskaAudioTrack(this.trackInfo, stream), localAudioTrackExecutor);
+			} else {
+				throw new RuntimeException("Unsupported audio codec " + codec);
 			}
 		}
 	}
@@ -38,5 +48,24 @@ public class RipSrcAudioTrack extends DelegatedAudioTrack {
 	@Override
 	public AudioSourceManager getSourceManager() {
 		return this.audioManager;
+	}
+
+	private static Map<String, String> parseQueryParams(String uri) {
+		try {
+			var parsedUri = new URI(uri);
+			var queryParams = parsedUri.getQuery();
+			var parsedParams = new HashMap<String, String>();
+
+			for (var pair : queryParams.split("&")) {
+				var splitIdx = pair.indexOf("=");
+				var key = splitIdx > 0 ? pair.substring(0, splitIdx) : pair;
+				var value = splitIdx > 0 && pair.length() > splitIdx + 1 ? pair.substring(splitIdx + 1) : null;
+				parsedParams.put(key, value);
+			}
+
+			return parsedParams;
+		} catch (URISyntaxException e) {
+			throw ExceptionTools.toRuntimeException(e);
+		}
 	}
 }


### PR DESCRIPTION
`PersistentHttpStream`'s third parameter takes a `long` with the value of the target stream's content length, not duration.