### PR TITLE
Implement stream retrying

### DIFF
--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioManager.java
@@ -134,15 +134,15 @@ public class RipSrcAudioManager implements HttpConfigurable, AudioSourceManager,
 		return null;
 	}
 
-	private AudioItem getTracksById(String id) {
+	public AudioItem getTracksById(String id) {
 		return this.loadTracks("tracks", id, false);
 	}
 
-	private AudioItem getTracksByISRC(String isrcs) {
+	public AudioItem getTracksByISRC(String isrcs) {
 		return this.loadTracks("isrcs", isrcs, false);
 	}
 
-	private AudioItem getSearch(String query) {
+	public AudioItem getSearch(String query) {
 		return this.loadTracks("q", query, true);
 	}
 

--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
@@ -96,7 +96,7 @@ public class RipSrcAudioTrack extends DelegatedAudioTrack {
 			long expireEpochMs = Long.parseLong(expires);
 
 			// safety buffer
-			if (System.currentTimeMillis() > expireEpochMs - TimeUnit.MINUTES.toMillis(5)) {
+			if (System.currentTimeMillis() < expireEpochMs - TimeUnit.MINUTES.toMillis(5)) {
 				return currentUrl;
 			}
 		} catch (NumberFormatException e) {

--- a/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
+++ b/main/src/main/java/com/kikkia/ripsrc/RipSrcAudioTrack.java
@@ -5,14 +5,17 @@ import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
 import com.sedmelluq.discord.lavaplayer.tools.Units;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
 import com.sedmelluq.discord.lavaplayer.track.*;
 import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
+import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class RipSrcAudioTrack extends DelegatedAudioTrack {
 	private final RipSrcAudioManager audioManager;
@@ -24,24 +27,89 @@ public class RipSrcAudioTrack extends DelegatedAudioTrack {
 
 	@Override
 	public void process(LocalAudioTrackExecutor localAudioTrackExecutor) throws Exception {
-		var downloadLink = this.trackInfo.uri;
-		var queryParams = parseQueryParams(downloadLink);
+		var initialStreamUrl = getStreamUrl();
+
+		try (HttpInterface httpInterface = audioManager.getHttpInterface()) {
+			process0(localAudioTrackExecutor, httpInterface, initialStreamUrl, 0, 1);
+		}
+	}
+
+	private void process0(
+		LocalAudioTrackExecutor executor,
+		HttpInterface httpInterface,
+		String streamUrl,
+		long streamPosition,
+		int retryAttempt
+	) throws Exception {
+		var queryParams = parseQueryParams(streamUrl);
 
 		var codec = queryParams.get("codec");
 		var contentLength = queryParams.get("clen");
+		var lastStreamPosition = streamPosition;
 
-		try (var httpInterface = this.audioManager.getHttpInterface();
-			 var stream = new PersistentHttpStream(httpInterface, new URI(downloadLink), contentLength != null ? Long.parseLong(contentLength) : Units.CONTENT_LENGTH_UNKNOWN)) {
+		try (var stream = new PersistentHttpStream(httpInterface, new URI(streamUrl), contentLength != null ? Long.parseLong(contentLength) : Units.CONTENT_LENGTH_UNKNOWN)) {
+			BaseAudioTrack track;
 
 			// Atm only see mpeg or webm
-			if (codec.contains("opus")) {
-				processDelegate(new MatroskaAudioTrack(this.trackInfo, stream), localAudioTrackExecutor);
+			if (codec == null || codec.contains("opus")) {
+				track = new MatroskaAudioTrack(this.trackInfo, stream);
 			} else if (codec.contains("mp4a")) {
-				processDelegate(new MpegAudioTrack(this.trackInfo, stream), localAudioTrackExecutor);
+				track = new MpegAudioTrack(this.trackInfo, stream);
 			} else {
 				throw new RuntimeException("Unsupported audio codec " + codec);
 			}
+
+			if (streamPosition > 0) stream.seek(streamPosition);
+
+			try {
+				processDelegate(track, executor);
+				// successful play, bail.
+				return;
+			} catch (RuntimeException e) {
+				// unexpected error or ran out of retries.
+				if (!"Not success status code: 403".equals(e.getMessage()) || retryAttempt >= 3) {
+					throw e;
+				}
+
+				lastStreamPosition = stream.getPosition();
+			}
 		}
+
+		// cycle here so that we don't keep the old stream open
+		this.process0(executor, httpInterface, getStreamUrl(), lastStreamPosition, retryAttempt + 1);
+	}
+
+	@NotNull
+	private String getStreamUrl() {
+		var currentUrl = this.trackInfo.uri;
+		var queryParams = parseQueryParams(currentUrl);
+		var expires = queryParams.get("expires");
+
+		if (expires == null) {
+			// we could just try and play it and safe and regenerate the URL
+			// but if we can't safely determine the expiration, we want to avoid
+			// spamming the server as much as possible.
+			return currentUrl;
+		}
+
+		try {
+			long expireEpochMs = Long.parseLong(expires);
+
+			// safety buffer
+			if (System.currentTimeMillis() > expireEpochMs - TimeUnit.MINUTES.toMillis(5)) {
+				return currentUrl;
+			}
+		} catch (NumberFormatException e) {
+			return currentUrl;
+		}
+
+		var renewedTrack = this.audioManager.getTracksById(trackInfo.identifier);
+
+		if (!(renewedTrack instanceof RipSrcAudioTrack)) {
+			throw new RuntimeException("Failed to regenerate stream URL");
+		}
+
+		return ((RipSrcAudioTrack) renewedTrack).trackInfo.uri;
 	}
 
 	@Override


### PR DESCRIPTION
Implements the ability to regenerate stream URLs.

Useful if, for example, you cache the track in a database, and then try to play it later. The cached version would still have an expired stream URL.
This is also useful in situations where a user may have the player paused long enough to outlast stream URL expiration.

In either case, a maximum of 3 retries is permitted before the track is written off and must either be regenerated, or reloaded into the player.

This also makes a few source manager methods public for direct invocation, if desired.